### PR TITLE
Added .gitignore + update Windows compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+
+opencraft.exe

--- a/build.bat
+++ b/build.bat
@@ -1,8 +1,8 @@
 @echo off
 setlocal enabledelayedexpansion
 
-set RAYLIB_INCLUDE=C:\raylib\include
-set RAYLIB_LIB=C:\raylib\lib
+set RAYLIB_INCLUDE=C:\raylib\w64devkit\x86_64-w64-mingw32\include
+set RAYLIB_LIB=C:\raylib\w64devkit\x86_64-w64-mingw32\lib
 
 set CC=gcc
 set CFLAGS=-I"%RAYLIB_INCLUDE%" -L"%RAYLIB_LIB%" -lraylib -lopengl32 -lgdi32 -lwinmm -static


### PR DESCRIPTION
## Update Winodws compiler
The path to raylib dependency is updated to remove compilation errors

## Added .gitignore
To ignore the `.vscode` folder and the executable `opencraft.exe`